### PR TITLE
Fix problem with S24_LE bit format

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -4,9 +4,15 @@ const flac = require('bindings')('flac-bindings');
 const Buffer = require('buffer').Buffer;
 
 const convertToInt32Buffer = (chunk, self) => {
-    if(self._inputAs32) return chunk;
+    let inBPS = readBytes = self._bitsPerSample / 8;
+    
+    if(self._inputAs32){
+        // S24_LE is 4 bytes in format xxxxxxxx xxxxxxxx xxxxxxxx 00000000
+        // We only want to read the first 3 bytes so leave readBytes as 3
+        inBPS = 4;
+    }
 
-    let inBPS = self._bitsPerSample / 8;
+    
     if(self._storedChunk) {
         chunk = Buffer.concat([ self._storedChunk, chunk ], self._storedChunk.length + chunk.length);
     }
@@ -14,7 +20,7 @@ const convertToInt32Buffer = (chunk, self) => {
     let samples = Math.trunc(chunk.length / inBPS);
     let buffer = Buffer.allocUnsafe(samples * 4);
     for(let i = 0; i < samples; i++) {
-        buffer.writeInt32LE(chunk.readIntLE(i * inBPS, inBPS), i * 4);
+        buffer.writeInt32LE(chunk.readIntLE(i * inBPS, readBytes), i * 4);
     }
 
     if(samples !== chunk.length / inBPS) {


### PR DESCRIPTION
If the chunk is passed as is, then the file size is ~25-30% larger than it should be and the resulting FLAC cannot be read correctly in Audacity.
Fix is to treat S24_LE as 32 bit but only read the first 3 bytes. The output is then identical to using S24_3LE.