### PR TITLE
Allow input of S32_LE byte format

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -5,13 +5,19 @@ const Buffer = require('buffer').Buffer;
 
 const convertToInt32Buffer = (chunk, self) => {
     let inBPS = readBytes = self._bitsPerSample / 8;
-    
     if(self._inputAs32){
         // S24_LE is 4 bytes in format xxxxxxxx xxxxxxxx xxxxxxxx 00000000
         // We only want to read the first 3 bytes so leave readBytes as 3
         inBPS = 4;
     }
-
+    
+    let byteOffset = 0;
+    if(self._bitsPerSample == 32){
+        // 24bit representation S32_LE is format 00000000 xxxxxxxx xxxxxxxx xxxxxxxx
+        // Offset read by one byte and read the next 3
+        byteOffset = 1;
+        readBytes = 3
+    }
     
     if(self._storedChunk) {
         chunk = Buffer.concat([ self._storedChunk, chunk ], self._storedChunk.length + chunk.length);
@@ -20,7 +26,7 @@ const convertToInt32Buffer = (chunk, self) => {
     let samples = Math.trunc(chunk.length / inBPS);
     let buffer = Buffer.allocUnsafe(samples * 4);
     for(let i = 0; i < samples; i++) {
-        buffer.writeInt32LE(chunk.readIntLE(i * inBPS, readBytes), i * 4);
+        buffer.writeInt32LE(chunk.readIntLE(i * inBPS + byteOffset, readBytes), i * 4);
     }
 
     if(samples !== chunk.length / inBPS) {
@@ -37,7 +43,7 @@ const setOptions = (self, options) => {
     self._oggStream = !!options.isOggStream;
     self._channels = Number(options.channels) || 2;
     self._bitsPerSample = Number(options.bitsPerSample) || 16;
-    self._inputAs32 = (options.inputAs32 !== undefined && options.inputAs32 !== null) ? Boolean(options.inputAs32) : (self._bitsPerSample === 24);
+    self._inputAs32 = (options.inputAs32 !== undefined && options.inputAs32 !== null) ? Boolean(options.inputAs32) : (self._bitsPerSample === 24 || self._bitsPerSample === 32);
     self._samplerate = Number(options.samplerate) || 44100;
     self._oggSerialNumber = Number(options.oggSerialNumber) || null;
     self._totalSamplesEstimate = Number(options.totalSamplesEstimate) || null;
@@ -58,7 +64,8 @@ const setOptions = (self, options) => {
 
 const setOptionsToEncoder = (self) => {
     flac.encoder.set_channels(self._enc, self._channels);
-    flac.encoder.set_bits_per_sample(self._enc, self._bitsPerSample);
+    // Max encoder bitsPerSample is 24
+    (self._bitsPerSample === 32) ? flac.encoder.set_bits_per_sample(self._enc, 24) : flac.encoder.set_bits_per_sample(self._enc, self._bitsPerSample);
     flac.encoder.set_sample_rate(self._enc, self._samplerate);
     if(self._oggStream && self._oggSerialNumber)
         flac.encoder.set_ogg_serial_number(self._enc, self._oggSerialNumber);


### PR DESCRIPTION
Most audio cards have no native support for S24_LE or S24_3LE so useful to allow S32_LE input.
Encoder is still set to 24 bit. Also allows encoding of 32Bit wav files.